### PR TITLE
Render class instead of className

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -94,7 +94,11 @@ export default function renderToJSON(vnode, context, opts, inner) {
 	};
 
 	if (attributes) {
-		ret.props = omit(attributes, ['key', 'children']);
+		ret.props = omit(attributes, ['key', 'children', 'className']);
+
+		if (attributes.className && !attributes.class) {
+			ret.props.class = attributes.className;
+		}
 	}
 
 	if (attributes && attributes.key) {

--- a/test/render.js
+++ b/test/render.js
@@ -1,0 +1,22 @@
+import { render } from '../src';
+import { h } from 'preact';
+import { expect } from 'chai';
+
+describe('className / class massaging', () => {
+	it('should render class using className', () => {
+		let rendered = render(<div className="foo bar" />);
+		expect(rendered.props).to.have.property('class', 'foo bar');
+		expect(rendered.props).to.not.have.property('className');
+	});
+
+	it('should render class using class', () => {
+		let rendered = render(<div class="foo bar" />);
+		expect(rendered.props).to.have.property('class', 'foo bar');
+	});
+
+	it('should prefer class over className', () => {
+		let rendered = render(<div class="foo" className="foo bar" />);
+		expect(rendered.props).to.have.property('class', 'foo');
+		expect(rendered.props).to.not.have.property('className');
+	});
+});


### PR DESCRIPTION
[preact-render-to-string](https://github.com/developit/preact-render-to-string) always renders `class` (instead of `className`), which is pretty useful - especially for [snapshot testing](https://github.com/styled-components/jest-styled-components/issues/80).

```js
if (name==='className') {
  if (attributes['class']) continue;
  name = 'class';
}
```
(see https://github.com/developit/preact-render-to-string/blob/master/src/index.js#L118)

This diff implements the same functionality for [preact-render-to-json](https://github.com/nathancahill/preact-render-to-json).